### PR TITLE
Fixed connections to submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,9 @@
 [submodule "src/pugixml"]
 	path = src/pugixml
 	url = https://github.com/joselusl/pugixml.git
-[submodule "raptor-dbw-ros"]
-	path = raptor-dbw-ros
+[submodule "src/ros_canopen"]
+	path = src/ros_canopen
+	url = https://github.com/ros-industrial/ros_canopen.git
+[submodule "src/raptor-dbw-ros"]
+	path = src/raptor-dbw-ros
 	url = https://github.com/NewEagleRaptor/raptor-dbw-ros.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/pugixml"]
+	path = src/pugixml
+	url = https://github.com/joselusl/pugixml.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/pugixml"]
 	path = src/pugixml
 	url = https://github.com/joselusl/pugixml.git
+[submodule "raptor-dbw-ros"]
+	path = raptor-dbw-ros
+	url = https://github.com/NewEagleRaptor/raptor-dbw-ros.git


### PR DESCRIPTION
Submodule links were broken.  This merge will repair the links so that anyone who checks out the repository will also automatically get the code for the submodules.

I used a GUI client to do checkouts, which prompts to "update submodules on checkout?" the first time I check out a branch or when I switch branches.  I am not sure what the commands would be at the command line (maybe `git submodule init` and `git submodule update`), but will check and document.